### PR TITLE
docs: Rename `PaneProps.api` to `PaneProps.pane`

### DIFF
--- a/sites/docs/content/components/pane.md
+++ b/sites/docs/content/components/pane.md
@@ -79,7 +79,7 @@ export type PaneProps = {
 	 * An imperative API for the pane. `bind` to this prop to get access
 	 * to methods for controlling the pane.
 	 */
-	api?: PaneAPI;
+	pane?: PaneAPI;
 } & Omit<HTMLAttributes<HTMLDivElement>, "id">;
 ```
 


### PR DESCRIPTION
The actual implementation:

https://github.com/svecosystem/paneforge/blob/7c8a1b0ddc2a60aae434eb9b20645456b12c94c4/packages/paneforge/src/lib/components/types.ts#L80