### PR TITLE
fix: Round values when determining if a pane is collapsed

### DIFF
--- a/packages/paneforge/src/lib/internal/paneforge.ts
+++ b/packages/paneforge/src/lib/internal/paneforge.ts
@@ -433,7 +433,7 @@ export function createPaneForge(props: CreatePaneForgeProps) {
 			paneSize,
 		} = paneDataHelper($paneDataArray, paneData, $layout);
 
-		return collapsible === true && paneSize === collapsedSize;
+		return collapsible === true && areNumbersAlmostEqual(paneSize, collapsedSize);
 	}
 
 	function expandPane(paneData: PaneData) {


### PR DESCRIPTION
Closes: https://github.com/svecosystem/paneforge/issues/74

I've reused areNumbersAlmostEqual (which by default checks if numbers are equal up to 10 decimal places) to determine if a pane is collapsed.
