### PR TITLE
fix: Round values when determining if a pane is collapsed

### DIFF
--- a/packages/paneforge/src/lib/paneforge.svelte.ts
+++ b/packages/paneforge/src/lib/paneforge.svelte.ts
@@ -336,7 +336,7 @@ export class PaneGroupState {
 			paneSize,
 		} = paneDataHelper(paneDataArray, pane, layout);
 
-		return collapsible === true && paneSize === collapsedSize;
+		return collapsible === true && areNumbersAlmostEqual(paneSize, collapsedSize);
 	};
 
 	expandPane = (pane: PaneState) => {


### PR DESCRIPTION
Closes: https://github.com/svecosystem/paneforge/issues/74

I've reused areNumbersAlmostEqual (which by default checks if numbers are equal up to 10 decimal places) to determine if a pane is collapsed.

(closed last PR because my fork was out of sync, sorry for the notification)